### PR TITLE
Relax constraints on GHC packages for 2014.2.0.0

### DIFF
--- a/platform/2014.2.0.0/cabal.config
+++ b/platform/2014.2.0.0/cabal.config
@@ -2,9 +2,9 @@
 -- Shipped with GHC 7.8.3
 
 constraints: array == 0.5.0.0,
-             base == 4.7.0.1,
+             base == 4.7.0.*,
              bytestring == 0.10.4.0,
-             Cabal == 1.18.1.3,
+             Cabal == 1.18.1.*,
              containers == 0.5.5.1,
              deepseq == 1.3.0.2,
              directory == 1.2.1.0,


### PR DESCRIPTION
This allows building against GHC 7.8.4 - travis doesn't seem to have 7.8.3 installed any longer.
